### PR TITLE
Feat/inkscape1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ Copy the contents to your Inkscape `extensions/` folder.
 
 Typical locations include:
 
-* OS X - `/Applications/Inkscape.app/Contents/Resources/extensions`
+* OS X 
+    * `/Applications/Inkscape.app/Contents/Resources/extensions` (application version specific)
+    * `~/Library/Application Support/org.inkscape.Inkscape/config/inkscape/extensions` (version agnostic)
 * Linux - `/usr/share/inkscape/extensions`
 * Windows - `C:\Program Files\Inkscape\share\extensions`
 
-you should have 2 files directly under the extensions folder (timsav_gcode.inx, timsave_gcode.py) and the timsav_gcode folder as well.
+you should have 2 files directly under the extensions folder (timsav_gcode.inx, timsav_gcode.py) and the timsav_gcode folder as well.
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ Usage
 	* Choose **Path | Object to Path**.
 * The path cutting orders are generated based on the svg document hierarchy, you can organize your paths with the XML editor.
     ![Document Property](doc/image2.png)
-    * For score cuts make the path strike **RED** #ff0000 (mind the lower case ff)
-    * For marking cuts make the path strike **BLUE** #0000ff (mind the lower case ff)
+    * For score cuts make the path stroke **RED** #ff0000 (mind the lower case ff)
+    * For marking cuts make the path stroke **BLUE** #0000ff (mind the lower case ff)
+    * For full cuts make the path stroke **BLACK** #000000 (all zeros)
+    * Any other path stroke color will not activate the cut.  (this is to prevent almost-red and almost-blue causing unwanted full cuts.)
     * The id of the path can be set with the editor and will be retained in the gcode's comment (helps with gcode troubleshooting)
 * Save as G-Code:
     ![Document Property](doc/image3.png)
@@ -61,6 +63,5 @@ Usage
 TODOs
 =====
 * Draw arrow for the direction of path for view
-* Rename `*PolyLine` stuff to `*Path` to be less misleading.
 * Parameterize smoothness for curve approximation.
 * Use native curve G-Codes instead of converting to paths?

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Disclaimer
 ===========================================
 I am not responsible for any damanage or harm that may have caused by this extension, do so at your own risk
 
+* Modified by: [David Just](https://github.com/DavidJJ/inkscape-timsav)
 * Modified by: [Spencer Schumann](https://github.com/spencerschumann)
 * Modified by: [Brian Ho](http://github.com/kawateihikaru)
 * Original Author: [Marty McGuire](http://github.com/martymcguire)

--- a/testcolors.svg
+++ b/testcolors.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e, 2022-07-14)"
+   sodipodi:docname="testcolors.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#999999"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.5584574"
+     inkscape:cx="537.7112"
+     inkscape:cy="393.33767"
+     inkscape:window-width="1799"
+     inkscape:window-height="1070"
+     inkscape:window-x="0"
+     inkscape:window-y="44"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:none;fill-opacity:0.352227;stroke:#000000;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.85714"
+       id="rect111"
+       width="41.529659"
+       height="37.754234"
+       x="32.720337"
+       y="46.563557" />
+    <ellipse
+       style="fill:none;fill-opacity:0.352227;stroke:#0000ff;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.85714"
+       id="path165"
+       cx="80.542366"
+       cy="171.78178"
+       rx="27.68644"
+       ry="28.315678" />
+    <path
+       sodipodi:type="star"
+       style="fill:none;fill-opacity:0.352227;stroke:#ff0000;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.85714"
+       id="path219"
+       inkscape:flatsided="false"
+       sodipodi:sides="5"
+       sodipodi:cx="128.3644"
+       sodipodi:cy="67.957626"
+       sodipodi:r1="35.617279"
+       sodipodi:r2="17.80864"
+       sodipodi:arg1="1.012197"
+       sodipodi:arg2="1.6405155"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="M 147.24152,98.161018 127.1238,85.723002 105.47261,95.244196 111.08515,72.26755 95.339375,54.618262 l 23.586455,-1.762331 11.91976,-20.429055 8.9647,21.887465 23.11259,5.023438 -18.04597,15.289529 z"
+       inkscape:transform-center-x="-0.76673051"
+       inkscape:transform-center-y="-2.6636797" />
+    <path
+       sodipodi:type="spiral"
+       style="fill:none;fill-rule:evenodd;stroke:#ffff00;stroke-width:0.264583"
+       id="path382"
+       sodipodi:cx="144.98579"
+       sodipodi:cy="114.25694"
+       sodipodi:expansion="1"
+       sodipodi:revolution="3"
+       sodipodi:radius="20.20579"
+       sodipodi:argument="-17.939066"
+       sodipodi:t0="0"
+       d="m 144.98579,114.25694 c 0.62139,0.80014 -0.772,1.23238 -1.32988,1.03279 -1.51183,-0.54089 -1.51134,-2.56441 -0.73568,-3.69256 1.38747,-2.018 4.31745,-1.9064 6.05522,-0.43858 2.55025,2.1541 2.31657,6.09551 0.14148,8.41789 -2.89906,3.09538 -7.8826,2.73337 -10.78056,-0.15562 -3.6468,-3.6355 -3.15364,-9.67403 0.45272,-13.14323 4.3678,-4.20166 11.46793,-3.57593 15.5059,0.74983 4.75861,5.09776 3.9995,13.26335 -1.04693,17.86856 -5.8263,5.31691 -15.0598,4.42391 -20.23123,-1.34403 -5.87612,-6.55389 -4.84891,-16.85696 1.64113,-22.5939 7.28084,-6.435976 18.65465,-5.274334 24.95657,1.93824 6.99632,8.00732 5.70009,20.45273 -2.23534,27.31923"
+       transform="translate(10.695673,14.939987)" />
+  </g>
+</svg>

--- a/timsav_gcode.inx
+++ b/timsav_gcode.inx
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>TimSav G-Code Output</_name>
+  <name>TimSav G-Code Output</name>
   <id>com.timsav.gcode</id>
   <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
   <dependency type="executable" location="extensions">timsav_gcode.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
   <param name="tab" type="notebook">
     <page name="plotter_setup" _gui-text="Setup">
       <param name="pen-up-cmd" type="string" default="M5" _gui-text="Pen Up command">M5</param>
@@ -22,11 +21,11 @@
   <output>
     <extension>.gcode</extension>
     <mimetype>application/x-gcode</mimetype>
-    <_filetypename>TimSav Cutter G-Code (*.gcode)</_filetypename>
-    <_filetypetooltip>Toolpath for the TimSav Needle Cutter</_filetypetooltip>
+    <filetypename>TimSav Cutter G-Code (*.gcode)</filetypename>
+    <filetypetooltip>Toolpath for the TimSav Needle Cutter</filetypetooltip>
     <dataloss>true</dataloss>
   </output>
   <script>
-    <command reldir="extensions" interpreter="python">timsav_gcode.py</command>
+    <command location="inx" interpreter="python">timsav_gcode.py</command>
   </script>
 </inkscape-extension>

--- a/timsav_gcode/context.py
+++ b/timsav_gcode/context.py
@@ -106,12 +106,18 @@ class GCodeContext:
                     print(line)
 
     def start(self, cut_type):
-        if cut_type == 2:
+        if cut_type == 1:
+            #Full cut
+            self.codes.append("%s S%0.2F (pen down through)" % (self.pen_down_cmd, self.pen_down_angle))
+        elif cut_type == 2:
+            #Score cut
             self.codes.append("%s S%0.2F (pen down score)" % (self.pen_down_cmd, self.pen_score_angle))
         elif cut_type == 3:
+            #Marking cut
             self.codes.append("%s S%0.2F (pen down draw)" % (self.pen_down_cmd, self.pen_mark_angle))
         else:
-            self.codes.append("%s S%0.2F (pen down through)" % (self.pen_down_cmd, self.pen_down_angle))
+            # Invalid color detected. Only pretend to cut.
+            self.codes.append("%s (pen down invalid color)" % self.pen_up_cmd)
         self.codes.append("G4 P%d (wait %dms)" % (self.start_delay, self.start_delay))
         self.drawing = True
 

--- a/timsav_gcode/entities.py
+++ b/timsav_gcode/entities.py
@@ -86,16 +86,16 @@ class Arc(Entity):
 		context.codes.append("")
 
 
-class PolyLine(Entity):
+class Path(Entity):
 	def __init__(self):
 		self.segments = None
 		self.cut_style = None
 
 	def __str__(self):
-		return "Polyline consisting of %d segments." % len(self.segments)
+		return "Path consisting of %d segments." % len(self.segments)
 
 	def get_gcode(self, context):
-		"""Emit gcode for drawing polyline"""
+		"""Emit gcode for drawing path"""
 		if hasattr(self, 'segments'):
 			for points in self.segments:
 				start = points[0]

--- a/timsav_gcode/svg_parser.py
+++ b/timsav_gcode/svg_parser.py
@@ -297,7 +297,7 @@ class SvgParser:
             # first apply the current matrix transform to this node's transform
 
             trans = Transform(node.get("transform"))
-            trans_new = trans_current * trans
+            trans_new = trans_current @ trans
 
             if node.tag == inkex.addNS('g', 'svg') or node.tag == 'g':
                 if node.get(inkex.addNS('groupmode', 'inkscape')) == 'layer':

--- a/timsav_gcode/svg_parser.py
+++ b/timsav_gcode/svg_parser.py
@@ -88,7 +88,7 @@ class SvgIgnoredEntity:
 class SvgPath(entities.PolyLine):
     def __init__(self):
         super().__init__()
-        self.cut_style = 1
+        self.cut_style = 0
 
     def load(self, node, trans):
         a = node.get('style').split(";")
@@ -97,7 +97,10 @@ class SvgPath(entities.PolyLine):
             self.cut_style = 2
         elif d['stroke'] == "#0000ff":
             self.cut_style = 3
+        elif d['stroke'] == "#000000":
+            self.cut_style = 1
         else:
+            inkex.errormsg(f"Warning: unable to draw node objID: {node.get('id')}. Invalid color detected: {d['stroke']}. Only Black, Red, and Blue are acceptable.")
             pass
 
         d = node.get('d')

--- a/timsav_gcode/svg_parser.py
+++ b/timsav_gcode/svg_parser.py
@@ -85,7 +85,7 @@ class SvgIgnoredEntity:
         return
 
 
-class SvgPath(entities.PolyLine):
+class SvgPath(entities.Path):
     def __init__(self):
         super().__init__()
         self.cut_style = 0


### PR DESCRIPTION
Made changes that seemed to be required for the plugin to work with Inkscape 1.2 on mac. 

Also made a change so that only valid colors are BLACK, RED, and BLUE since I shot myself in the foot by having a few "almost red" lines that were treated as full cuts.   Now it will pretend to cut any non recognized color but never drop the "pen" so as to not make invalid cuts. 